### PR TITLE
Added spago support

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -109,13 +109,13 @@ let additions =
 -}
 
 let mkPackage =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/0.12.3-20190226/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190607/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/spacchetti/spacchetti/0.12.3-20190226/src/packages.dhall sha256:832321319d21051fe1c0ff21bcee77af1f86bf7700d2041e1e1c1ac6b1dc4ea1
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190607/src/packages.dhall sha256:96b28e434b8a62caea5f10376b4f7dc1736a668592cabe914f117ecf5673c2ff
 
 let overrides = {=}
 
 let additions = {=}
 
-in  upstream ⫽ overrides ⫽ additions
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -11,8 +11,11 @@ You can edit this file as you like.
     , "debug"
     , "effect"
     , "kishimen"
+    , "node-child-process"
     , "node-fs"
     , "node-process"
+    , "parsing"
+    , "psci-support"
     , "simple-json"
     ]
 , packages =

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -3,6 +3,7 @@ module Main where
 import Prelude
 
 import Control.Alt ((<|>))
+import Data.Array (some)
 import Data.Array as A
 import Data.Either (Either(..), either)
 import Data.Foldable (intercalate, maximum)
@@ -11,28 +12,35 @@ import Data.Generic.Rep (class Generic)
 import Data.Maybe (fromMaybe)
 import Data.Newtype (class Newtype, unwrap)
 import Data.String as S
+import Data.String.CodeUnits (fromCharArray)
 import Data.String.CodeUnits as CU
+import Data.Traversable (traverse)
 import Data.Unfoldable (replicate)
 import Effect (Effect)
 import Effect.Aff (Aff, Error, attempt, launchAff_, makeAff, message, nonCanceler)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Class.Console (log, logShow)
-import Effect.Exception (catchException)
+import Effect.Exception (catchException, throw)
+import Effect.Exception as Ex
 import Foreign (Foreign)
 import Foreign.Object (Object)
 import Foreign.Object as Obj
 import Node.Buffer as Buffer
+import Node.ChildProcess as ChildProcess
 import Node.Encoding (Encoding(..))
+import Node.FS.Sync (exists, readTextFile)
 import Node.FS.Sync as FS
 import Node.Process (exit)
 import Simple.JSON (class ReadForeign, E, read, readImpl, readJSON)
+import Text.Parsing.Parser (Parser, runParser)
+import Text.Parsing.Parser.String (satisfy, skipSpaces)
 
 explodeIfLeft :: forall a. ReadForeign a => E a -> Aff a
 explodeIfLeft x = liftEffect $ case x of
-  Left e -> do 
+  Left e -> do
     logShow e
     exit (-1)
-  Right a -> 
+  Right a ->
     pure a
 
 type NpmResult = { report :: Object NpmEntry }
@@ -47,24 +55,24 @@ derive instance genericArrayOrString :: Generic ArrayOrString _
 type BowerEntry = { licenses :: ArrayOrString }
 
 npmToUnified :: String -> NpmEntry -> UnifiedResult
-npmToUnified name e = 
+npmToUnified name e =
   { depType: "npm", depName: name, depLicenses: intercalate ", " (unwrap e.license) }
 
 bowerToUnified :: String -> BowerEntry -> UnifiedResult
-bowerToUnified name e =  
+bowerToUnified name e =
   { depType: "bower", depName: unundefined name, depLicenses: intercalate ", " (unwrap e.licenses) }
   where
     unundefined = S.replace (S.Pattern "@undefined") (S.Replacement "")
 
 renderUnifiedResult :: UnifiedResult -> String
-renderUnifiedResult { depType, depName, depLicenses } = 
+renderUnifiedResult { depType, depName, depLicenses } =
   "|" <> depType <> "|" <> depName <> "|" <> depLicenses <> "|"
 
 foreign import npmCrawler :: Effect Unit
-foreign import bowerCrawlerImpl 
-  :: Fn3 (Error   -> Either Error Foreign) 
-         (Foreign -> Either Error Foreign) 
-         (Either Error Foreign -> Effect Unit) 
+foreign import bowerCrawlerImpl
+  :: Fn3 (Error   -> Either Error Foreign)
+         (Foreign -> Either Error Foreign)
+         (Either Error Foreign -> Effect Unit)
          (Effect Unit)
 
 bowerCrawler :: (Either Error Foreign -> Effect Unit) -> Effect Unit
@@ -73,7 +81,56 @@ bowerCrawler = runFn3 bowerCrawlerImpl Left Right
 fileName :: String
 fileName = "./tmpLicenses.json"
 
-type UnifiedResult = 
+isSpago :: Effect Boolean
+isSpago = exists "spago.dhall"
+
+spagoCrawler :: Effect (Array UnifiedResult)
+spagoCrawler =
+  do
+    transB <- ChildProcess.execSync "spago list-packages -f transitive" ChildProcess.defaultExecSyncOptions
+    trans <- Buffer.toString UTF8 transB
+    directB <- ChildProcess.execSync "spago list-packages -f direct" ChildProcess.defaultExecSyncOptions
+    direct <- Buffer.toString UTF8 directB
+    t <- either (throw <<< show) pure $ runParser trans spagoFormatParser
+    d <- either (throw <<< show) pure $ runParser direct spagoFormatParser
+    let
+      spagoResults = t <> d
+      getLicense :: _ -> _ { license :: String }
+      getLicense r = fileAsJSON ("./.spago/" <> r.name <> "/" <> r.version <> "/bower.json")
+      toUnifiedResult r = do
+        l <- getLicense r
+        pure { depName: r.name , depType: "spago" , depLicenses: l.license }
+    traverse toUnifiedResult spagoResults
+
+
+fileAsJSON :: forall m r. ReadForeign r => MonadEffect m => String -> m r
+fileAsJSON path = do
+  fileContent <- liftEffect $ readTextFile UTF8 path
+  liftEffect $ either
+    (\s -> Ex.throwException <<< Ex.error $ "Content of file " <> path <> " is not valid Json: " <> (show s))
+    pure
+    (readJSON fileContent)
+
+spagoFormatParser :: Parser String (Array SpagoResult)
+spagoFormatParser =
+  some $ do
+    name <- parseStringUntil ' '
+    skipSpaces
+    version <- parseStringUntil ' '
+    skipSpaces
+    url <- parseStringUntil '\n'
+    skipSpaces
+    pure { name, version, url }
+  where
+    parseStringUntil char = map fromCharArray $ some $ satisfy (\c -> c /= char)
+
+type SpagoResult =
+  { name :: String
+  , version :: String
+  , url :: String
+  }
+
+type UnifiedResult =
   { depLicenses :: String
   , depType :: String
   , depName :: String
@@ -94,16 +151,16 @@ depNameHeader = "Dependency name"
 depLicensesHeader :: String
 depLicensesHeader = "Licenses"
 
-printHeader :: forall m. MonadEffect m => MaxLengths -> m Unit 
+printHeader :: forall m. MonadEffect m => MaxLengths -> m Unit
 printHeader { maxDepType , maxDepName , maxDepLicense } = do
   log $ "# Licenses used by dependencies\n\n"
-     <> "|" <> spacePad maxDepType    depTypeHeader  
+     <> "|" <> spacePad maxDepType    depTypeHeader
      <> "|" <> spacePad maxDepName    depNameHeader
-     <> "|" <> spacePad maxDepLicense depLicensesHeader 
+     <> "|" <> spacePad maxDepLicense depLicensesHeader
      <> "|" <> "\n"
-     <> "|" <> rightPad '-' maxDepType "" 
-     <> "|" <> rightPad '-' maxDepName "" 
-     <> "|" <> rightPad '-' maxDepLicense "" 
+     <> "|" <> rightPad '-' maxDepType ""
+     <> "|" <> rightPad '-' maxDepName ""
+     <> "|" <> rightPad '-' maxDepLicense ""
      <> "|"
 
 calcMaxLengths :: Array UnifiedResult -> MaxLengths
@@ -116,19 +173,19 @@ calcMaxLengths results = { maxDepType, maxDepName, maxDepLicense }
 padResults :: MaxLengths -> Array UnifiedResult -> Array UnifiedResult
 padResults { maxDepType, maxDepName, maxDepLicense } = map f
   where
-    f { depType, depName, depLicenses } = 
+    f { depType, depName, depLicenses } =
       { depType: spacePad maxDepType depType
       , depName: spacePad maxDepName depName
       , depLicenses: spacePad maxDepLicense depLicenses
       }
 
 main :: Effect Unit
-main = launchAff_ do 
+main = launchAff_ do
   res <- attempt run
   either (log <<< message) pure res
 
 rightPad :: Char -> Int -> String -> String
-rightPad c n unpadded = 
+rightPad c n unpadded =
   let whiteSpaces = n - S.length unpadded in
     unpadded <> CU.fromCharArray (replicate whiteSpaces c)
 
@@ -142,10 +199,15 @@ run = do
   content :: NpmResult <- explodeIfLeft <<< readJSON $ file
   liftEffect $ catchException (const $ pure unit) (FS.unlink fileName)
   let npmResults = Obj.values $ Obj.mapWithKey npmToUnified content.report
-  rawBowerResults :: Foreign <- makeAff $ \cb -> bowerCrawler cb $> nonCanceler
-  bowerObject <- explodeIfLeft $ read rawBowerResults
-  let bowerResults = Obj.values $ Obj.mapWithKey bowerToUnified bowerObject
-  let combined = npmResults <> bowerResults
+  spago <- liftEffect isSpago
+  ps <-
+    if spago then
+      liftEffect spagoCrawler
+    else do
+      rawBowerResults :: Foreign <- makeAff $ \cb -> bowerCrawler cb $> nonCanceler
+      bowerObject <- explodeIfLeft $ read rawBowerResults
+      pure $ Obj.values $ Obj.mapWithKey bowerToUnified bowerObject
+  let combined = npmResults <> ps
   let sorted = A.sortWith _.depLicenses combined
   let maxLengths = calcMaxLengths sorted
   let padded = padResults maxLengths sorted


### PR DESCRIPTION
Picks spago over bower, if it exists. Looks up purescript dependency licenses by looking at `bower.json` of the dependencies and parsing the `license` field there.